### PR TITLE
Group access change of /etc/nginx/.htpasswd

### DIFF
--- a/docs/guides/webserver/nginx.md
+++ b/docs/guides/webserver/nginx.md
@@ -86,6 +86,7 @@
 
     ```bash
     htpasswd -c /etc/nginx/.htpasswd exampleuser
+    chmod 0640 /etc/nginx/.htpasswd
     ```
 
 8. Change ownership of the html directory to nginx user


### PR DESCRIPTION
pihole user belongs to group www-data, so I propose to change the group reading access of /etc/nginx/.htpasswd to allow login by .htpasswd. Thanks!

Signed-off-by: Marcelo Magalhaes <marcelo.marques.magalhaes@gmail.com>